### PR TITLE
Add continuous integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: Continuous integration
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Unit tests
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Run unit tests
+        run: ./gradlew test
+
+  apk:
+    name: Build APK
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build debug APK
+        run: ./gradlew assembleDebug


### PR DESCRIPTION
Add continuous integration (CI) with GitHub Actions. It runs the unit tests and builds a debug APK. It does not block bad commits (gated commits) but you will at least be able to see if a pull request breaks anything before pulling it.

I used the Github-Android-Action action from the Marketplace [[1]] as a starting point and modified it.

[1]: https://github.com/marketplace/actions/android-github-action