### PR TITLE
Fix hottest time of day

### DIFF
--- a/app/src/main/java/org/secuso/privacyfriendlyweather/ui/RecycleList/CityWeatherAdapter.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyweather/ui/RecycleList/CityWeatherAdapter.java
@@ -81,9 +81,10 @@ public class CityWeatherAdapter extends RecyclerView.Adapter<CityWeatherAdapter.
 
                 Calendar c = new GregorianCalendar();
                 c.setTime(f.getLocalForecastTime(context));
-              
+
                 //TODO replace with max and min values for the days
-                if (c.get(Calendar.HOUR_OF_DAY) < 14 && c.get(Calendar.HOUR_OF_DAY) > 10) {
+                int hourOfDay = c.get(Calendar.HOUR_OF_DAY);
+                if (13 < hourOfDay && hourOfDay < 17) {
                     forecastList.add(f);
                 }
             }


### PR DESCRIPTION
The hottest time of day is usually around 15:00. The code assumed it was after 10:00 and before 14:00. This change adjusts the range to after 13:00 and before 17:00. This makes the daily high for the course of the week much more accurate.

It is still a hack because there might be a rain storm that comes through during those times. The TODO comment that was already present suggested to find the maximum instead, which is the correct solution. I propose to use this until the correct solution is implemented.