### PR TITLE
Add support for inches as unit of rainfall measure

### DIFF
--- a/app/src/main/java/org/secuso/privacyfriendlyweather/backup/BackupRestorer.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyweather/backup/BackupRestorer.java
@@ -69,6 +69,7 @@ public class BackupRestorer implements IBackupRestorer {
                 case "widgetChoice3":
                 case "widgetChoice4":
                 case "distanceUnit":
+                case "precipitationAmountUnit":
                 case "temperatureUnit":
                 case "API_key_value":
                     pref.edit().putString(name, reader.nextString()).apply();

--- a/app/src/main/java/org/secuso/privacyfriendlyweather/preferences/AppPreferencesManager.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyweather/preferences/AppPreferencesManager.java
@@ -97,6 +97,23 @@ public class AppPreferencesManager {
     }
 
     /**
+     * This method converts a given distance value into the unit that was set in the preferences.
+     *
+     * @param millimeters The millimeters to convert into the unit that is set in the preferences.
+     *                   Make sure to pass a value in millimeters.
+     * @return Returns the converted distance.
+     */
+    public float convertPrecipitationAmountFromMillimeters(float millimeters) {
+        // 1 = millimeters, 2 = inches
+        int prefValue = Integer.parseInt(preferences.getString("precipitationAmountUnit", "1"));
+        if (prefValue == 1) {
+            return millimeters;
+        } else {
+            return convertMmInInches(millimeters);
+        }
+    }
+
+    /**
      * @return Returns true if kilometers was set as distance unit in the preferences else false.
      */
     public boolean isDistanceUnitKilometers() {
@@ -109,6 +126,22 @@ public class AppPreferencesManager {
      */
     public boolean isDistanceUnitMiles() {
         int prefValue = Integer.parseInt(preferences.getString("distanceUnit", "0"));
+        return (prefValue == 2);
+    }
+
+    /**
+     * @return Returns true if millimeters was set as precipitation amount unit in the preferences else false.
+     */
+    public boolean isPrecipitationMeasureMillimeters() {
+        int prefValue = Integer.parseInt(preferences.getString("precipitationAmountUnit", "0"));
+        return (prefValue == 1);
+    }
+
+    /**
+     * @return Returns true if incges was set as precipitation amount unit in the preferences else false.
+     */
+    public boolean isPrecipitationMeasureInches() {
+        int prefValue = Integer.parseInt(preferences.getString("precipitationAmountUnit", "0"));
         return (prefValue == 2);
     }
 
@@ -135,6 +168,28 @@ public class AppPreferencesManager {
     }
 
     /**
+     * Converts a kilometer value in miles.
+     *
+     * @param km The value to convert to miles.
+     * @return Returns the converted value.
+     */
+    public float convertMmInInches(float mm) {
+        // TODO: Is this the right class for the function???
+        return (float) (mm / 25.4);
+    }
+
+    /**
+     * Converts a miles value in kilometers.
+     *
+     * @param miles The value to convert to kilometers.
+     * @return Returns the converted value.
+     */
+    public float convertInchesInMm(float incges) {
+        // TODO: Is this the right class for the function???
+        return (float) (inches * 25.4);
+    }
+
+    /**
      * @return Returns "°C" in case Celsius is set and "°F" if Fahrenheit was selected.
      */
     public String getWeatherUnit() {
@@ -155,6 +210,18 @@ public class AppPreferencesManager {
             return "km";
         } else {
             return "mi";
+        }
+    }
+
+    /**
+     * @return Returns "nn" in case millimeter is set and "in" if inches was selected.
+     */
+    public String getPrecipitationAmountUnit() {
+        int prefValue = Integer.parseInt(preferences.getString("precipitationAmountUnit", "1"));
+        if (prefValue == 1) {
+            return "mm";
+        } else {
+            return "in";
         }
     }
 

--- a/app/src/main/java/org/secuso/privacyfriendlyweather/ui/RecycleList/CourseOfDayAdapter.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyweather/ui/RecycleList/CourseOfDayAdapter.java
@@ -127,7 +127,7 @@ public class CourseOfDayAdapter extends RecyclerView.Adapter<CourseOfDayAdapter.
         if (courseOfDayList.get(position).getRainValue() == 0)
             holder.precipitation.setText("-");
         else
-            holder.precipitation.setText(StringFormatUtils.formatDecimal(courseOfDayList.get(position).getRainValue(), "mm"));
+            holder.precipitation.setText(StringFormatUtils.formatDecimal(prefManager.convertPrecipitationAmountFromMillimeters(courseOfDayList.get(position).getRainValue()), prefManager.getPrecipitationAmountUnit()));
     }
 
     //update header according to date in first visible item on the left of recyclerview

--- a/app/src/main/java/org/secuso/privacyfriendlyweather/ui/RecycleList/WeekWeatherAdapter.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyweather/ui/RecycleList/WeekWeatherAdapter.java
@@ -53,7 +53,7 @@ public class WeekWeatherAdapter extends RecyclerView.Adapter<WeekWeatherAdapter.
 
         setIcon((int) dayValues[9], holder.weather);
         holder.humidity.setText(StringFormatUtils.formatInt(dayValues[2], "%rh"));
-        holder.precipitation.setText(StringFormatUtils.formatDecimal(dayValues[4], "mm"));
+        holder.precipitation.setText(StringFormatUtils.formatDecimal(prefManager.convertPrecipitationAmountFromMillimeters(dayValues[4]), prefManager.getPrecipitationAmountUnit()));
         holder.rain_probability.setText(StringFormatUtils.formatInt(dayValues[11], "%\uD83D\uDCA7"));
         holder.uv_index.setText(String.format("UV %s", StringFormatUtils.formatInt(Math.round(dayValues[7]))));
         holder.wind_speed.setText(prefManager.convertToCurrentSpeedUnit(dayValues[5]));

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -18,6 +18,14 @@
         <item>1</item>
         <item>2</item>
     </string-array>
+    <string-array name="precipitationAmountUnitsArray">
+        <item>@string/settings_millimeters</item>
+        <item>@string/settings_inches</item>
+    </string-array>
+    <string-array name="precipitationAmountUnitsBalues">
+        <item>1</item>
+        <item>2</item>
+    </string-array>
 
     <string-array name="speedUnitsValues">
         <item>1</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,9 +95,13 @@
     <string name="settings_celsius">Celsius</string>
     <string name="settings_fahrenheit">Fahrenheit</string>
     <string name="settings_summary_distance">Set the unit to use for displaying distances</string>
+    <string name="settings_summary_precipitation_amount">Set the unit to use for displaying precipitation amount</string>
     <string name="settings_title_distance">Distances</string>
     <string name="settings_kilometers">Kilometers</string>
     <string name="settings_miles">Miles</string>
+    <string name="settings_title_precipitation_amount">Precipitation</string>
+    <string name="settings_millimeters">Millimeters</string>
+    <string name="settings_inches">Inches</string>
 
     <string name="settings_title_API">API Key</string>
     <string name="settings_description_API">Privacy Friendly Weather receives data from the free service of openweathermap.org. This service is limited to 1000 calls per day. You could register your own API key for free to get your own 1000 calls. Otherwise, calls are shared between all users of Privacy Friendly Weather.</string>

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -18,6 +18,13 @@
             android:summary="@string/settings_summary_distance"
             android:title="@string/settings_title_distance" />
         <ListPreference
+            android:defaultValue="1"
+            android:entries="@array/precipitationAmountUnitsArray"
+            android:entryValues="@array/precipitationAmountUnitsValues"
+            android:key="precipitationAmountUnit"
+            android:summary="@string/settings_summary_precipitation_amount"
+            android:title="@string/settings_title_precipitation_amount" />
+        <ListPreference
             android:defaultValue="6"
             android:entries="@array/speedUnitsArray"
             android:entryValues="@array/speedUnitsValues"


### PR DESCRIPTION
This addresses half of issue 171 by adding inches as a unit of measure for rainfall. This is very important for American users. We have no clue what a mm is! :)

Please note that I don't know how to compile Android apps, so this is not compiled or tested. But the code is so simple that I'm 99% confident that it will work on your first build.